### PR TITLE
Fix auto download if public MUC JID is in roster

### DIFF
--- a/libdino/src/service/file_manager.vala
+++ b/libdino/src/service/file_manager.vala
@@ -173,10 +173,16 @@ public class FileManager : StreamInteractionModule, Object {
     public void add_file_decryptor(FileDecryptor decryptor) {
         file_decryptors.add(decryptor);
     }
-
+    
     public bool is_sender_trustworthy(FileTransfer file_transfer, Conversation conversation) {
         if (file_transfer.direction == FileTransfer.DIRECTION_SENT) return true;
-        Jid relevant_jid = stream_interactor.get_module(MucManager.IDENTITY).get_real_jid(file_transfer.from, conversation.account) ?? conversation.counterpart;
+
+        Jid relevant_jid = conversation.counterpart;
+        if (conversation.type_ == Conversation.Type.GROUPCHAT) {
+            relevant_jid = stream_interactor.get_module(MucManager.IDENTITY).get_real_jid(file_transfer.from, conversation.account);
+        }
+        if (relevant_jid == null) return false;
+
         bool in_roster = stream_interactor.get_module(RosterManager.IDENTITY).get_roster_item(conversation.account, relevant_jid) != null;
         return in_roster;
     }


### PR DESCRIPTION
Set relevant JID to the conversation counterpart by default and only if it's a MUC to the real JID instead.
If the real JID of the MUC occupant is known, check if it's in the roster, so that files are downloaded automatically in private MUCs, where we know everyone.